### PR TITLE
Calculate and Query Prize Pool

### DIFF
--- a/packages/snfoundry/contracts/src/prize_pool.cairo
+++ b/packages/snfoundry/contracts/src/prize_pool.cairo
@@ -124,6 +124,15 @@ mod PrizePool {
         fn get_platform_reserves(ref self: ContractState) -> u256 {
             self.platform_reserves.read()
         }
+
+        fn addToPool(ref self: ContractState, amount: u256){
+            
+            assert(!amount.is_zero(), "Ticket amount must be greater than zero");
+
+            let current_total = self.totalPool.read();
+            let new_total = current_total + amount;
+            self.totalPool.write(new_total);
+        }
     }
 
 

--- a/packages/snfoundry/contracts/src/prize_pool.cairo
+++ b/packages/snfoundry/contracts/src/prize_pool.cairo
@@ -8,8 +8,8 @@ trait IPrizePool<TContractState> {
     fn withdraw_reserves(ref self: TContractState, amount: u256, recipient: ContractAddress);
     fn get_platform_fee(ref self: TContractState) -> u256;
     fn get_platform_reserves(ref self: TContractState) -> u256;
-    fn addToPool(ref self: ContractState, amount: u256);
-    fn getPool(ref self: ContractState) -> u256;
+    fn add_Pool(ref self: ContractState, amount: u256);
+    fn get_Pool(ref self: ContractState) -> u256;
 }
 #[starknet::contract]
 mod PrizePool {
@@ -125,7 +125,7 @@ mod PrizePool {
             self.platform_reserves.read()
         }
 
-        fn addToPool(ref self: ContractState, amount: u256){
+        fn add_Pool(ref self: ContractState, amount: u256){
             
             assert(!amount.is_zero(), "Ticket amount must be greater than zero");
 
@@ -134,7 +134,7 @@ mod PrizePool {
             self.totalPool.write(new_total);
         }
 
-        fn getPoolTotal(ref self: ContractState) -> u256 {
+        fn get_Pool(ref self: ContractState) -> u256 {
             self.totalPool.read();
         }
     }

--- a/packages/snfoundry/contracts/src/prize_pool.cairo
+++ b/packages/snfoundry/contracts/src/prize_pool.cairo
@@ -8,6 +8,8 @@ trait IPrizePool<TContractState> {
     fn withdraw_reserves(ref self: TContractState, amount: u256, recipient: ContractAddress);
     fn get_platform_fee(ref self: TContractState) -> u256;
     fn get_platform_reserves(ref self: TContractState) -> u256;
+    fn addToPool(ref self: ContractState, amount: u256);
+    fn getPool(ref self: ContractState) -> u256;
 }
 #[starknet::contract]
 mod PrizePool {

--- a/packages/snfoundry/contracts/src/prize_pool.cairo
+++ b/packages/snfoundry/contracts/src/prize_pool.cairo
@@ -71,6 +71,10 @@ mod PrizePool {
         
         // Initial platform fee: 10% 
         self.platform_fee_percentage.write(10_u256);
+        // Initialize platform reserves (if not already defaulting to 0)
+        self.platform_reserves.write(0_u256);
+        // --- Initialize the total prize pool to zero ---
+        self.totalPool.write(0_u256);
     }
 
     #[abi(embed_v0)]

--- a/packages/snfoundry/contracts/src/prize_pool.cairo
+++ b/packages/snfoundry/contracts/src/prize_pool.cairo
@@ -133,6 +133,10 @@ mod PrizePool {
             let new_total = current_total + amount;
             self.totalPool.write(new_total);
         }
+
+        fn getPoolTotal(ref self: ContractState) -> u256 {
+            self.totalPool.read();
+        }
     }
 
 

--- a/packages/snfoundry/contracts/src/prize_pool.cairo
+++ b/packages/snfoundry/contracts/src/prize_pool.cairo
@@ -31,6 +31,7 @@ mod PrizePool {
         erc20: ERC20Component::Storage,
         platform_fee_percentage: u256,
         platform_reserves: u256,
+        totalPool: u256,
     }
 
     #[event]

--- a/packages/snfoundry/contracts/src/test/test_prize_pool.cairo
+++ b/packages/snfoundry/contracts/src/test/test_prize_pool.cairo
@@ -140,4 +140,20 @@ mod tests {
         let pool_after_second_add = prize_pool.get_Pool();
         assert_eq!(pool_after_second_add, 750_u256);
     }
+
+    #[test_case]
+    fn test_get_pool_total() {
+        let contract_class: ContractClass = declare("PrizePool");
+        let contract: PreparedContract = contract_class.deploy();
+
+        let admin: ContractAddress = ContractAddress::from_felt(0x123456);
+        let fee_setter: ContractAddress = ContractAddress::from_felt(0x789abc);
+
+        let prize_pool: ContractInvoker<PrizePool> = contract.into();
+        prize_pool.constructor(admin, fee_setter);
+
+        // Without adding any tickets, the prize pool total should be zero.
+        let pool_total = prize_pool.getPoolTotal();
+        assert_eq!(pool_total, 0_u256);
+    }
 }

--- a/packages/snfoundry/contracts/src/test/test_prize_pool.cairo
+++ b/packages/snfoundry/contracts/src/test/test_prize_pool.cairo
@@ -110,4 +110,34 @@ mod tests {
         assert_eq!(initial_fee, 10_u256);
         assert_eq!(initial_reserves, 0_u256);
     }
+
+    #[test_case]
+    fn test_add_to_pool() {
+        let contract_class: ContractClass = declare("PrizePool");
+        let contract: PreparedContract = contract_class.deploy();
+
+        let admin: ContractAddress = ContractAddress::from_felt(0x123456);
+        let fee_setter: ContractAddress = ContractAddress::from_felt(0x789abc);
+
+        let prize_pool: ContractInvoker<PrizePool> = contract.into();
+        prize_pool.constructor(admin, fee_setter);
+
+        // Initially, the total prize pool should be 0.
+        let initial_pool = prize_pool.get_Pool();
+        assert_eq!(initial_pool, 0_u256);
+
+        // Add a ticket of 500 tokens.
+        prize_pool.add_Pool(500_u256);
+
+        // Verify the pool total has increased to 500.
+        let pool_after_first_add = prize_pool.get_Pool();
+        assert_eq!(pool_after_first_add, 500_u256);
+
+        // Add another ticket of 250 tokens.
+        prize_pool.add_Pool(250_u256);
+
+        // Verify the total accumulates to 750.
+        let pool_after_second_add = prize_pool.get_Pool();
+        assert_eq!(pool_after_second_add, 750_u256);
+    }
 }


### PR DESCRIPTION
# Pull Request Description

Closes #4 
This pull request introduces two new functions in the `PrizePool` contract:

## New Functions

1. **`addToPool`**:
   - Accepts a ticket amount (of type `u256`).
   - Validates that the amount is nonzero.
   - Adds the amount to the persistent state variable `totalPool`.

2. **`getPoolTotal`**:
   - A view function that returns the current total value of the prize pool.

## Modifications

### Storage Update
- Added a new state variable `totalPool` (initialized to zero in the constructor) to the storage struct.

### New Functions Implementation
- Implemented `addToPool` and `getPoolTotal` following the existing coding patterns.

### Testing
- Added two new test cases in `test_prize_pool.cairo`:
  1. **`test_add_to_pool`**:
     - Verifies that adding amounts via `addToPool` correctly updates the pool total.
  2. **`test_get_pool_total`**:
     - Checks that `getPoolTotal` returns zero when no tickets have been added.